### PR TITLE
fixed notice in php 5.6

### DIFF
--- a/lib/DVelopment/FastBill/Model/ProjectFbApi.php
+++ b/lib/DVelopment/FastBill/Model/ProjectFbApi.php
@@ -11,6 +11,7 @@ namespace DVelopment\FastBill\Model;
 
 use DVelopment\FastBill\Model\Response\ProjectResponse;
 use JMS\Serializer\Annotation as JMS;
+use DVelopment\FastBill\Model\Response\Response;
 
 /**
  * @JMS\XmlRoot("FBAPI")
@@ -38,7 +39,7 @@ class ProjectFbApi extends FbApi
      *
      * @return ProjectFbApi
      */
-    public function setResponse($response)
+    public function setResponse(Response $response)
     {
         $this->response = $response;
 


### PR DESCRIPTION
Runtime Notice: Declaration of DVelopment\FastBill\Model\ProjectFbApi::setResponse() should be compatible with DVelopment\FastBill\Model\FbApi::setResponse(DVelopment\FastBill\Model\Response\Response
   $response)
